### PR TITLE
Recovers from the failure if name/md5sum is absent in the sketches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI Pipeline
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
-      - main
+      - '**'
 
 jobs:
   build-and-test:

--- a/src/compare.cpp
+++ b/src/compare.cpp
@@ -100,8 +100,25 @@ void do_compare(Arguments& args) {
         }
     }
 
+    // create the directory of output file if it does not exist
+    string output_dir = args.output_filename.substr(0, args.output_filename.find_last_of("/"));
+    struct stat info;
+    if (stat(output_dir.c_str(), &info) != 0) {
+        cout << "The directory " << output_dir << " does not exist. Creating..." << endl;
+        // create the directory
+        string create_dir_command = "mkdir -p " + output_dir;
+        if (system(create_dir_command.c_str()) != 0) {
+            cerr << "Error in creating the directory " << output_dir << endl;
+            exit(1);
+        }
+    }
+
     // write the header in the output file
     ofstream output_file(args.output_filename);
+    if (!output_file.is_open()) {
+        cerr << "Error in opening the output file " << args.output_filename << endl;
+        exit(1);
+    }
     output_file << "query_id,query_name,query_md5,query_sketch_size,match_id,match_name,match_md5,match_sketch_size,jaccard,containment_query_in_match,containment_match_in_query,max_containment,max_containment_ani" << endl;
     output_file.close();
 
@@ -111,6 +128,7 @@ void do_compare(Arguments& args) {
         combine_command += filename + " ";
     }
     combine_command += " >> " + args.output_filename;
+    cout << "Combining small files by the command: " << combine_command << endl;
     // call the system command and check if it is successful
     if (system(combine_command.c_str()) != 0) {
         cerr << "Error in combining the files." << endl;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,7 +42,7 @@ Sketch read_min_hashes(const std::string& json_filename) {
     }
     
     try {
-        md5 = jsonData[0]["md5"];
+        md5 = jsonData[0]["md5sum"];
     } catch (json::exception& e) {
         // crash
         //std::cerr << "Error: " << e.what() << std::endl;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,13 +15,73 @@ Sketch read_min_hashes(const std::string& json_filename) {
     json jsonData;
     inputFile >> jsonData;
 
+    // data
+    std::vector<hash_t> min_hashes;
+    std::string name;
+    std::string md5;
+    int ksize;
+    hash_t max_hash;
+    int seed;
+
     // Access and print values
-    std::vector<hash_t> min_hashes = jsonData[0]["signatures"][0]["mins"];
-    std::string name = jsonData[0]["name"];
-    std::string md5 = jsonData[0]["signatures"][0]["md5sum"];
-    int ksize = jsonData[0]["signatures"][0]["ksize"];
-    hash_t max_hash = jsonData[0]["signatures"][0]["max_hash"];
-    int seed = jsonData[0]["signatures"][0]["seed"];
+    try {
+        std::vector<hash_t> min_hashes_loaded = jsonData[0]["signatures"][0]["mins"];
+        min_hashes = min_hashes_loaded;
+    } catch (json::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: cannot find the mins in filename: " << json_filename << std::endl;
+        std::cerr << "Error: The file is may not be a valid sketch file!" << std::endl;
+        exit(1);
+    }
+    
+    try {
+        name = jsonData[0]["name"];
+    } catch (json::exception& e) {
+        std::cerr << "Warning: no name found in: " << json_filename << ", using empty string" << std::endl;
+        name = "";
+    }
+    
+    try {
+        md5 = jsonData[0]["md5"];
+    } catch (json::exception& e) {
+        // crash
+        //std::cerr << "Error: " << e.what() << std::endl;
+        //std::cerr << "Error: cannot find the md5 in filename: " << json_filename << std::endl;
+        //std::cerr << "Error: The file is may not be a valid sketch file!" << std::endl;
+        //exit(1);
+        std::cerr << "Warning: no md5 found in: " << json_filename << ", using empty string" << std::endl;
+        md5 = "";
+    }
+
+    try{
+        ksize = jsonData[0]["signatures"][0]["ksize"];
+    } catch (json::exception& e) {
+        // crash
+        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: cannot find the ksize in filename: " << json_filename << std::endl;
+        std::cerr << "Error: The file is may not be a valid sketch file!" << std::endl;
+        exit(1);
+    }
+
+    try {
+        max_hash = jsonData[0]["signatures"][0]["max_hash"];
+    } catch (json::exception& e) {
+        // crash
+        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: cannot find the max_hash in filename: " << json_filename << std::endl;
+        std::cerr << "Error: The file is may not be a valid sketch file!" << std::endl;
+        exit(1);
+    }
+    
+    try {
+        seed = jsonData[0]["signatures"][0]["seed"];
+    } catch (json::exception& e) {
+        // crash
+        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << "Error: cannot find the seed in filename: " << json_filename << std::endl;
+        std::cerr << "Error: The file is may not be a valid sketch file!" << std::endl;
+        exit(1);
+    }
 
     // Close the file
     inputFile.close();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,7 +42,7 @@ Sketch read_min_hashes(const std::string& json_filename) {
     }
     
     try {
-        md5 = jsonData[0]["md5sum"];
+        md5 = jsonData[0]["signatures"][0]["md5sum"];
     } catch (json::exception& e) {
         // crash
         //std::cerr << "Error: " << e.what() << std::endl;


### PR DESCRIPTION
- md5sum is required by the test scripts
- continue on error if name is absent (empty name used)
- continue on error if md5sum is absent (empty string is used)